### PR TITLE
Fix build issues when attempt to integrate OpenBW

### DIFF
--- a/bwapi/BWAPI/CMakeLists.txt
+++ b/bwapi/BWAPI/CMakeLists.txt
@@ -5,7 +5,10 @@ include_directories(
   ./Source
   ../BWAPICore
   ../Shared
+  ../OpenBWData
 )
+
+add_definitions(-DDEBUG_NEW)
 
 add_library(BWAPIObj OBJECT
   Source/Config.cpp

--- a/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
@@ -210,7 +210,7 @@ void AutoMenuManager::onMenuFrame()
 
 #ifdef _DEBUG
   // Wait for a debugger if autoMenuPause is enabled, and in DEBUG
-  if (this->autoMenuPause != "OFF" && !IsDebuggerPresent())
+  if (this->autoMenuPause != "OFF")
     return;
 #endif
 

--- a/bwapi/OpenBWData/BW/BWData.cpp
+++ b/bwapi/OpenBWData/BW/BWData.cpp
@@ -316,6 +316,7 @@ struct ui_wrapper {
   }
 };
 struct draw_ui_wrapper {
+  draw_ui_wrapper(bwgame::state& st, std::string mpq_path) {}
   std::tuple<int, int, uint32_t*> draw(int x, int y, int width, int height) {
     return {0, 0, nullptr};
   }


### PR DESCRIPTION
* AutoMenuManager.cpp produces error that symbol `IsDebuggerPresent` was not defined. Remove debugger check, since it is not useful
* I was forced to add DEBUG_NEW to be able compile `GameInternals.cpp`, Maybe some additional configuration is required, maybe some flags, etc. But for me this work well
* bwapi/OpenBWData/BW/BWData.cpp When compiled and OPENBW_ENABLE_UI is not defined, it was required to have such constructor, same as in the path where OPENBW_ENABLE_UI is defined.