### PR TITLE
More explicit error message when no map filename is defined is bwapi.ini

### DIFF
--- a/bwapi/OpenBWData/BW/BWData.cpp
+++ b/bwapi/OpenBWData/BW/BWData.cpp
@@ -480,6 +480,8 @@ struct game_setup_helper_t {
     vars.left_game = false;
     vars.is_multi_player = true;
 
+    if ( vars.set_map_filename.empty() )
+      error("No map filename. Maybe the 'map' parameter is missing from bwapi-data/bwapi.ini.");
     auto& filename = vars.set_map_filename;
 
     auto& global_st = *st.global;


### PR DESCRIPTION
Should solve https://github.com/OpenBW/openbw/issues/4.