### PR TITLE
Address Errors and Warnings

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/GameDrawing.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameDrawing.cpp
@@ -224,8 +224,9 @@ namespace BWAPI
       switch ( s )
       {
         case BWAPIC::ShapeType::Text:
-           bwDrawText(x1,y1,shapeStrings.at(shape.extra1).c_str(),ctype,(char)shape.extra2);
-           break;
+          if (shape.extra1 >= shapeStrings.size()) break;
+          bwDrawText(x1,y1,shapeStrings.at(shape.extra1).c_str(),ctype,(char)shape.extra2);
+          break;
         case BWAPIC::ShapeType::Box:
           x2 = shape.x2;
           y2 = shape.y2;

--- a/bwapi/OpenBWData/BW/BWData.cpp
+++ b/bwapi/OpenBWData/BW/BWData.cpp
@@ -318,7 +318,7 @@ struct ui_wrapper {
 struct draw_ui_wrapper {
   draw_ui_wrapper(bwgame::state& st, std::string mpq_path) {}
   std::tuple<int, int, uint32_t*> draw(int x, int y, int width, int height) {
-    return {0, 0, nullptr};
+    return std::tuple<int, int, uint32_t*>(0, 0, nullptr);
   }
 };
 
@@ -1587,7 +1587,7 @@ void Game::setRandomSeed(uint32_t value)
   impl->st.lcg_rand_state = value;
 }
 
-void Game::disableTriggers()  
+void Game::disableTriggers()
 {
   impl->st.trigger_timer = -1;
 }

--- a/bwapi/include/BWAPI/BestFilter.h
+++ b/bwapi/include/BWAPI/BestFilter.h
@@ -18,7 +18,7 @@ namespace BWAPI
     // Constructor
     template <typename _T>
     BestFilter(const _T &predicate) : pred(predicate)
-    {};
+    {}
 
     // Assignment
     template <typename _T>
@@ -26,20 +26,20 @@ namespace BWAPI
     {
       this->pred = other;
       return *this;
-    };
+    }
 
     // Bitwise operators
     template <typename _T>
     inline BestFilter<_PARAM> operator &&(const _T &other) const
     {
       return [=](_PARAM p1, _PARAM p2)->_PARAM{ return other( (*this)(p1, p2) ); };
-    };
+    }
 
     // call
     inline _PARAM operator()(const _PARAM &p1, const _PARAM &p2) const
     {
       return this->pred(p1, p2);
-    };
+    }
 
   };
 
@@ -47,12 +47,12 @@ namespace BWAPI
   BestFilter<_PARAM> Lowest(const CompareFilter<_PARAM,int> &filter)
   {
     return [=](_PARAM p1, _PARAM p2)->_PARAM{ return filter(p2) < filter(p1) ? p2 : p1; };
-  };
+  }
   template <typename _PARAM>
   BestFilter<_PARAM> Highest(const CompareFilter<_PARAM,int> &filter)
   {
     return [=](_PARAM p1, _PARAM p2)->_PARAM{ return filter(p2) > filter(p1) ? p2 : p1; };
-  };
+  }
 
 }
 

--- a/bwapi/include/BWAPI/BulletType.h
+++ b/bwapi/include/BWAPI/BulletType.h
@@ -120,6 +120,6 @@ namespace BWAPI
     constexpr BulletType Neutron_Flare{Enum::Neutron_Flare};
     constexpr BulletType None{Enum::None};
     constexpr BulletType Unknown{Enum::Unknown};
-  };
+  }
   static_assert(sizeof(BulletType) == sizeof(int), "Expected type to resolve to primitive size.");
 }

--- a/bwapi/include/BWAPI/ComparisonFilter.h
+++ b/bwapi/include/BWAPI/ComparisonFilter.h
@@ -62,27 +62,27 @@ namespace BWAPI
     // Division
     template <typename T>
     CompareFilter<PType,RType,std::function<RType(PType)> > operator /(const T &other) const
-    {   
+    {
       return [=](PType v)->int{ int rval = other(v);
                                  return rval == 0 ? std::numeric_limits<int>::max() : (*this)(v) / rval;
                                };
-    };
+    }
 
     // Modulus
     template <typename T>
     CompareFilter<PType,RType,std::function<RType(PType)> > operator %(const T &other) const
-    {   
+    {
       return [=](PType v)->int{ int rval = other(v);
                                  return rval == 0 ? 0 : (*this)(v) % rval;
                                };
-    };
+    }
 
     // call
     inline RType operator()(PType u) const
     {
       return pred(u);
     };
-    
+
     inline bool isValid() const
     {
       return (bool)pred;

--- a/bwapi/include/BWAPI/Error.h
+++ b/bwapi/include/BWAPI/Error.h
@@ -48,9 +48,9 @@ namespace BWAPI
         Unknown,
         MAX
       };
-    };
-  };
-  
+    }
+  }
+
   /// <summary>The Error object is generally used to determine why certain functions in BWAPI
   /// have failed.</summary>
   ///
@@ -71,7 +71,7 @@ namespace BWAPI
     ///
     /// @returns Set of error types.
     const Error::set& allErrors();
-    
+
     constexpr Error Unit_Does_Not_Exist{Enum::Unit_Does_Not_Exist};
     constexpr Error Unit_Not_Visible{Enum::Unit_Not_Visible};
     constexpr Error Unit_Not_Owned{Enum::Unit_Not_Owned};

--- a/bwapi/include/BWAPI/ExplosionType.h
+++ b/bwapi/include/BWAPI/ExplosionType.h
@@ -43,8 +43,8 @@ namespace BWAPI
         Unknown,
         MAX
       };
-    };
-  };
+    }
+  }
   /// <summary>A representation of a weapon's explosion type.</summary> This indicates how the
   /// weapon behaves, such as if it deals splash damage or causes an effect to occur.
   ///

--- a/bwapi/include/BWAPI/Game.h
+++ b/bwapi/include/BWAPI/Game.h
@@ -33,7 +33,7 @@ namespace BWAPI
   typedef PlayerInterface *Player;
   class Playerset;
   class Race;
-  
+
   class RegionInterface;
   typedef RegionInterface *Region;
 
@@ -218,7 +218,7 @@ namespace BWAPI
     /// Example:
     /// @code
     ///   BWAPI::Broodwar->setLocalSpeed(0);
-    ///   
+    ///
     ///   // Log and display the best logical FPS seen in the game
     ///   static int bestFPS = 0;
     ///   bestFPS = std::max(bestFPS, BWAPI::Broodwar->getFPS());
@@ -460,7 +460,7 @@ namespace BWAPI
     ///   The distance from \p center to search for units. If omitted, then the entire map is
     ///   searched.
     /// </param>
-    /// 
+    ///
     /// @returns The desired unit that best matches the given criteria.
     /// @retval nullptr if a suitable unit was not found.
     ///
@@ -604,7 +604,7 @@ namespace BWAPI
     /// <param name="tileY">
     ///   The y value of the tile to check.
     /// </param>
-    /// 
+    ///
     /// @returns boolean identifying the visibility of the tile. If the given tile is visible, then
     /// the value is true. If the given tile is concealed by the fog of war, then this value will
     /// be false.
@@ -622,7 +622,7 @@ namespace BWAPI
     /// <param name="tileY">
     ///   The y tile coordinate to check.
     /// </param>
-    /// 
+    ///
     /// @retval true If the player has explored the given tile position (partially revealed fog).
     /// @retval false If the tile position was never explored (completely black fog).
     ///
@@ -680,7 +680,7 @@ namespace BWAPI
     ///   omitted, then only the immediate tile position is checked for power, and the function
     ///   will assume that the location requires power for any unit type.
     /// </param>
-    ///   
+    ///
     /// @retval true if the type at the given tile position will receive power.
     /// @retval false if the type will be unpowered at the given tile position.
     bool hasPower(int tileX, int tileY, UnitType unitType = UnitTypes::None) const;
@@ -792,9 +792,9 @@ namespace BWAPI
     /// <summary>Prints text to the screen as a notification.</summary> This function allows text
     /// formatting using Text::Enum members. The behaviour of this function is the same as printf,
     /// located in header cstdio.
-    /// 
+    ///
     /// @note That text printed through this function is not seen by other players or in replays.
-    /// 
+    ///
     /// <param name="format">
     ///   Text formatting. See std::printf for more information. Refrain from passing non-constant
     ///   strings directly in this parameter.
@@ -816,7 +816,7 @@ namespace BWAPI
     ///
     /// @see printf
 /*55*/    virtual void vPrintf(const char *format, va_list args) = 0;
-    
+
     /// <summary>Sends a text message to all other players in the game.</summary> The behaviour of
     /// this function is the same as std::printf, located in header cstdio.
     ///
@@ -829,7 +829,7 @@ namespace BWAPI
     ///
     /// @see sendTextEx, std::printf
     void sendText(const char *format, ...);
-    
+
     /// @copydoc sendText
     ///
     /// This function is intended to forward an already-existing argument list.
@@ -856,7 +856,7 @@ namespace BWAPI
     ///
     /// @see sendText, std::printf
     void sendTextEx(bool toAllies, const char *format, ...);
-    
+
     /// @copydoc sendTextEx
     ///
     /// This function is intended to forward an already-existing argument list.
@@ -959,13 +959,13 @@ namespace BWAPI
     /// <summary>Retrieves the set of units that are currently selected by the user outside of
     /// BWAPI.</summary> This function requires that Flag::UserInput be enabled.
     ///
-    /// @returns A Unitset containing the user's selected units. If Flag::UserInput is disabled, 
+    /// @returns A Unitset containing the user's selected units. If Flag::UserInput is disabled,
     /// then this set is always empty.
     ///
     /// @see enableFlag
     virtual const Unitset& getSelectedUnits() const = 0;
 
-    /// <summary>Retrieves the player object that BWAPI is controlling.</summary> 
+    /// <summary>Retrieves the player object that BWAPI is controlling.</summary>
     ///
     /// @returns Pointer to Player interface object representing the current player.
     /// @retval nullptr if the current game is a replay.
@@ -1318,7 +1318,7 @@ namespace BWAPI
     /// frame.
     /// @see getRemainingLatencyTime, getLatencyFrames
     virtual int getRemainingLatencyFrames() const = 0;
-    
+
     /// <summary>Retrieves the number of milliseconds it will take before a command sent in the
     /// current frame will be executed by Broodwar.</summary>
     ///
@@ -1450,7 +1450,7 @@ namespace BWAPI
     ///
     /// @note If making queries on a unit, it's better to call UnitInterface::hasPath, since it is
     /// a more lenient version of this function that accounts for some edge cases.
-    /// 
+    ///
     /// <param name="source">
     ///   The source position.
     /// </param>
@@ -1568,7 +1568,7 @@ namespace BWAPI
     ///         - Cancel_Upgrade
     ///         .
     ///       .
-    ///     - 3: Extensive optimization 
+    ///     - 3: Extensive optimization
     ///       - Includes the optimizations made by all previous levels.
     ///       - Units may behave or move differently than expected.
     ///       - Units performing the following actions are grouped and ordered 12 at a time:
@@ -1730,7 +1730,7 @@ namespace BWAPI
     /// @returns This game's random seed.
     /// @since 4.2.0
     virtual unsigned getRandomSeed() const = 0;
-    
+
     virtual void setCharacterName(const std::string& name) = 0;
     virtual void setGameType(GameType gameType) = 0;
     virtual void setAIModule(AIModule* module) = 0;
@@ -1775,10 +1775,10 @@ namespace BWAPI
       // Pass whatever into the stream
       ss << in;
       return *this;
-    };
+    }
     /// @overload
     GameWrapper &operator <<(ostream_manipulator fn);
-    
+
     /// <summary>Flushes the Broodwar stream, printing all text in the stream to the screen.</summary>
     void flush();
   };

--- a/bwapi/include/BWAPI/GameType.h
+++ b/bwapi/include/BWAPI/GameType.h
@@ -37,8 +37,8 @@ namespace BWAPI
         Unknown,
         MAX
       };
-    };
-  };
+    }
+  }
   /// <summary>A class that represents game types in Broodwar.</summary> A game type is selected
   /// when creating a game.
   ///
@@ -58,7 +58,7 @@ namespace BWAPI
     ///
     /// @returns Set of available GameTypes.
     const GameType::set& allGameTypes();
-    
+
     constexpr GameType Melee{Enum::Melee};
     constexpr GameType Free_For_All{Enum::Free_For_All};
     constexpr GameType One_on_One{Enum::One_on_One};

--- a/bwapi/include/BWAPI/Interface.h
+++ b/bwapi/include/BWAPI/Interface.h
@@ -49,7 +49,7 @@ namespace BWAPI
     /// <param name="key">
     ///   The key containing the value to retrieve. Default is 0.
     /// </param>
-    /// 
+    ///
     /// @retval nullptr if index is out of bounds.
     /// @returns The client info at the given index.
     /// @see setClientInfo
@@ -70,7 +70,7 @@ namespace BWAPI
     CT getClientInfo(int key = 0) const
     {
       return (CT)(long)this->getClientInfo(key);
-    };
+    }
 
     /// <summary>Associates one or more pointers or values with any BWAPI interface.</summary>
     ///
@@ -89,10 +89,10 @@ namespace BWAPI
     ///
     /// @see getClientInfo
     template < typename V >
-    void setClientInfo(const V &clientInfo, int key = 0)
+    void setClientInfo(const V &clientInfoIn, int key = 0)
     {
-      this->clientInfo[key] = (void*)clientInfo;
-    };
+      this->clientInfo[key] = (void*)clientInfoIn;
+    }
 
     /// <summary>Registers an event and associates it with the current Interface object.</summary>
     /// Events can be used to automate tasks (like train X @Marines until Y of them have been

--- a/bwapi/include/BWAPI/Order.h
+++ b/bwapi/include/BWAPI/Order.h
@@ -388,7 +388,7 @@ namespace BWAPI
     constexpr Order Fatal{Enum::Fatal};
     constexpr Order None{Enum::None};
     constexpr Order Unknown{Enum::Unknown};
-  };
+  }
 
   static_assert(sizeof(Order) == sizeof(int), "Expected type to resolve to primitive size.");
 }

--- a/bwapi/include/BWAPI/Player.h
+++ b/bwapi/include/BWAPI/Player.h
@@ -654,4 +654,4 @@ namespace BWAPI
     virtual void setMinerals(int value)= 0;
     virtual void setGas(int value) = 0;
   };
-};
+}

--- a/bwapi/include/BWAPI/PlayerType.h
+++ b/bwapi/include/BWAPI/PlayerType.h
@@ -30,10 +30,10 @@ namespace BWAPI
         Unknown,
         MAX
       };
-    };
-  };
+    }
+  }
   /// <summary>Represents the type of controller for the player slot (i.e. human, computer).</summary>
-  /// 
+  ///
   /// @see PlayerTypes
   /// @ingroup TypeClasses
   class PlayerType : public Type<PlayerType, PlayerTypes::Enum::Unknown>
@@ -64,7 +64,7 @@ namespace BWAPI
     ///
     /// @returns Set consisting of all valid PlayerTypes.
     const PlayerType::set& allPlayerTypes();
-    
+
     constexpr PlayerType None{Enum::None};
     constexpr PlayerType Computer{Enum::Computer};
     constexpr PlayerType Player{Enum::Player};

--- a/bwapi/include/BWAPI/Position.h
+++ b/bwapi/include/BWAPI/Position.h
@@ -88,15 +88,15 @@ namespace BWAPI
     /// <summary>A convenience for use with if statements to identify if a position is valid.</summary>
     /// @see isValid
     explicit operator bool() const { return this->isValid(); };
-    
+
     bool operator == (const Point<T,Scale> &pos) const
-    { 
+    {
       return std::tie(this->x, this->y) == std::tie(pos.x, pos.y);
-    }; 
+    };
     bool operator != (const Point<T,Scale> &pos) const
-    { 
+    {
       return !(*this == pos);
-    }; 
+    };
 
     /// <summary>A less than operator that enables positions to be used by additional STL containers.</summary>
     /// Compares lexicographically the x position, followed by the y position.
@@ -275,7 +275,7 @@ namespace BWAPI
     {
       return ((*this) - position).getLength();
     };
-    
+
     /// <summary>Gets the length of this point from the top left corner of the map.</summary>
     ///
     /// @note This function impedes performance. In most cases you should use getApproxDistance.
@@ -284,11 +284,11 @@ namespace BWAPI
     /// @see getApproxDistance
     double getLength() const
     {
-      double x = (double)this->x;
-      double y = (double)this->y;
-      return sqrt(x * x + y * y);
+      double localX = (double)this->x;
+      double localY = (double)this->y;
+      return sqrt(localX * localX + localY * localY);
     };
-    
+
     /// <summary>Retrieves the approximate distance using an algorithm from Starcraft: Broodwar.</summary>
     ///
     /// @note This is a direct distance calculation that ignores all collision.
@@ -311,12 +311,12 @@ namespace BWAPI
         std::swap(min, max);
 
       if ( min < (max >> 2) )
-        return max;
+        return (int)max;
 
       unsigned int minCalc = (3*min) >> 3;
-      return (minCalc >> 5) + minCalc + max - (max >> 4) - (max >> 6);
+      return (int)((minCalc >> 5) + minCalc + max - (max >> 4) - (max >> 6));
     };
-    
+
     /// <summary>Sets the maximum x and y values.</summary> If the  current x or y values exceed
     /// the given maximum, then values are set to the maximum.
     ///
@@ -343,7 +343,7 @@ namespace BWAPI
       this->setMax(max.x, max.y);
       return *this;
     };
-    
+
     /// <summary>Sets the minimum x and y values.</summary> If the current x or y values are
     /// below the given minimum, then values are set to the minimum.
     ///
@@ -384,7 +384,7 @@ namespace BWAPI
   /// <summary>The scale of a @ref Position. Each position corresponds to a 1x1 pixel area.</summary>
   /// @see Position
   const int POSITION_SCALE = 1;
-  
+
   /// <summary>The scale of a @ref WalkPosition. Each walk position corresponds to an 8x8 pixel area.</summary>
   /// @see WalkPosition
   const int WALKPOSITION_SCALE = 8;

--- a/bwapi/include/BWAPI/Race.h
+++ b/bwapi/include/BWAPI/Race.h
@@ -28,7 +28,7 @@ namespace BWAPI
         Unknown,
         MAX
       };
-    };
+    }
   }
 
   /// <summary>The Race object is used to get information about a particular race.</summary> For
@@ -44,7 +44,7 @@ namespace BWAPI
       constexpr Race(int id = Races::Enum::None) : Type(id) {}
 
       /// <summary>Retrieves the default worker type for this Race.</summary>
-      /// 
+      ///
       /// @note In Starcraft, workers are the units that are used to construct structures.
       ///
       /// @returns UnitType of the worker that this race uses.
@@ -55,7 +55,7 @@ namespace BWAPI
       ///
       /// @note In Starcraft, the center is the very first structure of the Race's technology
       /// tree. Also known as its base of operations or resource depot.
-      /// 
+      ///
       /// @returns UnitType of the center that this race uses.
       ///
       /// @since 4.2.0
@@ -74,16 +74,16 @@ namespace BWAPI
       ///
       /// @note In Starcraft, you must first construct a structure over a @Geyser in order to
       /// begin harvesting Vespene Gas.
-      /// 
+      ///
       /// @returns UnitType of the structure used to harvest gas.
       UnitType getRefinery() const;
 
-      /// <summary>Retrieves the default transport UnitType for this race that is used to transport ground 
+      /// <summary>Retrieves the default transport UnitType for this race that is used to transport ground
       /// units across the map.</summary>
       ///
       /// @note In Starcraft, transports will allow you to carry ground units over unpassable
       /// terrain.
-      /// 
+      ///
       /// @returns UnitType for transportation.
       UnitType getTransport() const;
 
@@ -92,7 +92,7 @@ namespace BWAPI
       ///
       /// @note In Starcraft, training, morphing, or warping in units requires that the player
       /// has sufficient supply available for their Race.
-      /// 
+      ///
       /// @returns UnitType that provides the player with supply.
       UnitType getSupplyProvider() const;
   };

--- a/bwapi/include/BWAPI/Region.h
+++ b/bwapi/include/BWAPI/Region.h
@@ -133,4 +133,4 @@ namespace BWAPI
     /// @see UnitFilter
     Unitset getUnits(const UnitFilter &pred = nullptr) const;
   };
-};
+}

--- a/bwapi/include/BWAPI/TechType.h
+++ b/bwapi/include/BWAPI/TechType.h
@@ -62,7 +62,7 @@ namespace BWAPI
         Unknown,
         MAX
       };
-    };
+    }
   }
   /// <summary>The TechType (or Technology Type, also referred to as an Ability) represents a Unit's ability
   /// which can be researched with UnitInterface::research or used with UnitInterface::useTech.</summary>
@@ -208,7 +208,7 @@ namespace BWAPI
 
     constexpr TechType None{Enum::None};
     constexpr TechType Unknown{Enum::Unknown};
-  };
+  }
 
   static_assert(sizeof(TechType) == sizeof(int), "Expected type to resolve to primitive size.");
 }

--- a/bwapi/include/BWAPI/TournamentAction.h
+++ b/bwapi/include/BWAPI/TournamentAction.h
@@ -15,7 +15,7 @@ namespace BWAPI
 
       /// @see Game::pauseGame
       PauseGame,
-      
+
       /// @see Game::resumeGame
       ResumeGame,
 
@@ -50,5 +50,5 @@ namespace BWAPI
       SetCommandOptimizationLevel
     };
 
-  };
-};
+  }
+}

--- a/bwapi/include/BWAPI/UnaryFilter.h
+++ b/bwapi/include/BWAPI/UnaryFilter.h
@@ -30,38 +30,38 @@ namespace BWAPI
     UnaryFilter(const T &predicate) : pred(predicate) {}
 
     // Default copy/move ctor/assign and dtor
-    
+
     // logical operators
     template <typename T>
     inline UnaryFilter<PType,std::function<bool(PType)> > operator &&(const T& other) const
     {
       return [=](PType v){ return (*this)(v) && other(v); };
-    };
+    }
 
     template <typename T>
     inline UnaryFilter<PType,std::function<bool(PType)> > operator ||(const T& other) const
     {
       return [=](PType v){ return (*this)(v) || other(v); };
-    };
+    }
 
     inline UnaryFilter<PType,std::function<bool(PType)> > operator !() const
     {
       if ( !this->pred )
         return nullptr;
       return [=](PType v){ return !(*this)(v); };
-    };
+    }
 
     // call
     inline bool operator()(PType v) const
     {
       return pred(v);
-    };
+    }
 
     // operator bool
     inline bool isValid() const
     {
       return (bool)pred;
-    };
+    }
 
   };
 

--- a/bwapi/include/BWAPI/UnitCommand.h
+++ b/bwapi/include/BWAPI/UnitCommand.h
@@ -77,11 +77,11 @@ namespace BWAPI
       bool operator!=(const UnitCommand& other) const;
 
       template <class T, int S>
-      void assignTarget(Point<T, S> target)
+      void assignTarget(Point<T, S> targetIn)
       {
-        target.makeValid();
-        x = target.x;
-        y = target.y;
+        targetIn.makeValid();
+        x = targetIn.x;
+        y = targetIn.y;
       }
 
       Unit unit = nullptr;

--- a/bwapi/include/BWAPI/UnitCommandType.h
+++ b/bwapi/include/BWAPI/UnitCommandType.h
@@ -63,8 +63,8 @@ namespace BWAPI
         Unknown,
         MAX
       };
-    };
-  };
+    }
+  }
   /// <summary>A representation of a unit command in BWAPI.</summary> This is used by bots to
   /// notify BWAPI which commands to use. BWAPI filters commands accordingly and then converts
   /// them to Broodwar commands, which differ in complexity.
@@ -85,7 +85,7 @@ namespace BWAPI
     ///
     /// @returns Set of UnitCommandTypes.
     const UnitCommandType::set& allUnitCommandTypes();
-    
+
     constexpr UnitCommandType Attack_Move{Enum::Attack_Move};
     constexpr UnitCommandType Attack_Unit{Enum::Attack_Unit};
     constexpr UnitCommandType Build{Enum::Build};

--- a/bwapi/include/BWAPI/UnitSizeType.h
+++ b/bwapi/include/BWAPI/UnitSizeType.h
@@ -26,8 +26,8 @@ namespace BWAPI
         Unknown,
         MAX
       };
-    };
-  };
+    }
+  }
 
   /// <summary>Size types are used by unit types in Broodwar to determine how much damage will be
   /// applied.</summary> This corresponds with DamageType for several different damage reduction
@@ -51,7 +51,7 @@ namespace BWAPI
     ///
     /// @returns Set of all UnitSizeTypes.
     const UnitSizeType::set& allUnitSizeTypes();
-    
+
     constexpr UnitSizeType Independent{Enum::Independent};
     constexpr UnitSizeType Small{Enum::Small};
     constexpr UnitSizeType Medium{Enum::Medium};

--- a/bwapi/include/BWAPI/UnitType.h
+++ b/bwapi/include/BWAPI/UnitType.h
@@ -263,7 +263,7 @@ namespace BWAPI
         MAX
       };
 
-    };
+    }
   }
   /// <summary>The UnitType is used to get information about a particular type of unit, such as its cost,
   /// build time, weapon, hit points, abilities, etc.</summary>
@@ -305,7 +305,7 @@ namespace BWAPI
     /// @retval TechTypes::None If creating this unit type does not require a technology to be
     /// researched.
     TechType requiredTech() const;
-    
+
     /// <summary>Retrieves the cloaking technology associated with certain units.</summary>
     ///
     /// @returns TechType referring to the cloaking technology that this unit type uses as an
@@ -409,7 +409,7 @@ namespace BWAPI
 
     /// <summary>Retrieves the amount of space provided by this @Bunker or @Transport for unit
     /// transportation.</summary>
-    /// 
+    ///
     /// @returns The number of slots provided by this unit type.
     /// @see spaceRequired
     int spaceProvided() const;
@@ -831,7 +831,7 @@ namespace BWAPI
     bool producesLarva() const;
 
     /// <summary>Checks if this unit type is a mineral field and contains a resource amount.</summary>
-    /// This indicates that the unit type is either UnitTypes::Resource_Mineral_Field, 
+    /// This indicates that the unit type is either UnitTypes::Resource_Mineral_Field,
     /// UnitTypes::Resource_Mineral_Field_Type_2, or UnitTypes::Resource_Mineral_Field_Type_3.
     ///
     /// @returns true if this unit type is a mineral field resource.
@@ -879,7 +879,7 @@ namespace BWAPI
     const UnitType::set& buildsWhat() const;
 
     /// <summary>Retrieves the set of technologies that this unit type is capable of researching.</summary>
-    /// 
+    ///
     /// @note Some maps have special parameters that disable certain technologies. Use
     /// PlayerInterface::isResearchAvailable to determine if a technology is actually available in the
     /// current game for a specific player.
@@ -940,7 +940,7 @@ namespace BWAPI
     ///
     /// @returns The maximum width of all unit types, in pixels.
     int maxUnitWidth();
-    
+
     /// <summary>Retrieves the maximum unit height from the set of all units.</summary> Used
     /// internally to search through unit positions efficiently.
     ///


### PR DESCRIPTION
Using version gcc/g++ 5.4.0, compiling with gcc11 and g++14 I had a build issue, which this pull request fixes.
* Fix a build issue when returning a tuple as part of the UI wrapper draw
* Check if the text shape is within the list bounds before access
* Address shadow and pedantic warnings