### PR TITLE
Fix bug and warning message

### DIFF
--- a/bwapi/BWAPILauncher/Source/Main.cpp
+++ b/bwapi/BWAPILauncher/Source/Main.cpp
@@ -37,8 +37,10 @@ int main() {
         h->onGameEnd();
         h->bwgame.leaveGame();
       } while (!h->bwgame.gameClosed() && h->autoMenuManager.autoMenuRestartGame != "" && h->autoMenuManager.autoMenuRestartGame != "OFF");
+      return 0;
     } catch (const std::exception& e) {
       printf("Error: %s\n", e.what());
+      return 1;
     }
   });
 


### PR DESCRIPTION
Bug:
- Without the changes in this commit, "Aborted (core dumped)" is
displayed when the window closes in Release mode with UI. If OpenBW is
built with no UI, a seg fault is displayed. This does not seem to occur
in Debug mode.

Warning message:
- The changes in this commit fix the following warning message when
building OpenBW in Linux:

```
bwapi/bwapi/BWAPILauncher/Source/Main.cpp: In lambda function:
bwapi/bwapi/BWAPILauncher/Source/Main.cpp:43:3: warning: control reaches end of non-void function [-Wreturn-type]
   });
   ^
```