### PR TITLE
Fix bug with "isWinner"

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
@@ -408,9 +408,11 @@ namespace BWAPI
 
     if ( !this->calledMatchEnd )
     {
+      const bool isWinner = this->self() && this->self()->isVictorious();
+
       this->calledMatchEnd = true;
       events.push_back(Event::MatchFrame());
-      events.push_back(Event::MatchEnd(false));
+      events.push_back(Event::MatchEnd(isWinner));
       server.update();
       this->inGame = false;
       events.push_back(Event::MenuFrame());


### PR DESCRIPTION
- Regardless if the "self" bot wins or loses, the "onEnd" callback
reports a loss. The change in this commit will check if the self
player exists and also if he is victorious. This mimics similar code
seen in "GameUpdate.cpp#L54-L63":
https://github.com/OpenBW/bwapi/blob/a50f1b95efcfdc3faeae727a3979fff57672fd5b/bwapi/BWAPI/Source/GameUpdate.cpp#L54-L63