### PR TITLE
Include missing <cstdint>

### DIFF
--- a/bwapi/include/BWAPI/Game.h
+++ b/bwapi/include/BWAPI/Game.h
@@ -2,6 +2,7 @@
 #include <list>
 #include <string>
 #include <cstdarg>
+#include <cstdint>
 #include <vector>
 #include <tuple>
 


### PR DESCRIPTION
Without this I get a bunch of errors like 

```
In file included from /build/bwapi/bwapi/BWAPILIB/Source/Playerset.cpp:7:
/build/bwapi/bwapi/include/BWAPI/Game.h:1749:32: error: 'uint32_t' has not been declared
 1749 |     virtual void setRandomSeed(uint32_t value) = 0;
      |                                ^~~~~~~~
/build/bwapi/bwapi/include/BWAPI/Game.h:1752:34: error: 'uint32_t' was not declared in this scope
 1752 |     virtual std::tuple<int, int, uint32_t*> drawGameScreen(int x, int y, int width, int height) = 0;
      |                                  ^~~~~~~~
```